### PR TITLE
Improve test setup

### DIFF
--- a/src/main/java/BriscolaCommandHandler.java
+++ b/src/main/java/BriscolaCommandHandler.java
@@ -14,7 +14,7 @@ public class BriscolaCommandHandler {
     public void handle(CreateGame command) {
         Game game = new Game(command.gameId, command.gameName);
 
-        eventStore.appendToStream(game.getId(), game.changes(), -1);
+        eventStore.appendToStream(game.getId(), game.changes(), EventStore.APPEND_ANYWAY);
     }
 
     @Subscribe

--- a/src/main/java/EventStore.java
+++ b/src/main/java/EventStore.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 
 public interface EventStore {
 
+    int APPEND_ANYWAY = -1;
+
     void appendToStream(UUID aggregateId, List<Event> events, int expectedVersion);
 
     EventStream loadEventStream(UUID aggregateId);

--- a/src/main/java/InMemoryEventStore.java
+++ b/src/main/java/InMemoryEventStore.java
@@ -54,7 +54,7 @@ public class InMemoryEventStore implements EventStore {
     }
 
     private boolean conflictExists(int expectedVersion, List<EventDescriptor> eventDescriptors) {
-        return eventDescriptors.get(eventDescriptors.size() - 1).version != expectedVersion && expectedVersion != -1;
+        return eventDescriptors.get(eventDescriptors.size() - 1).version != expectedVersion && expectedVersion != APPEND_ANYWAY;
     }
 
 }

--- a/src/test/java/CardCanBePlayed.java
+++ b/src/test/java/CardCanBePlayed.java
@@ -1,6 +1,8 @@
-import events.CardPlayed;
+import events.*;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import static java.util.UUID.randomUUID;
@@ -11,38 +13,48 @@ public class CardCanBePlayed {
 
     @Test
     public void by_players_during_their_turn() {
-        Game game = new Game(id, gameName);
-        game.addPlayer(playerName + "1");
-        game.addPlayer(playerName + "2");
-        game.addPlayer(playerName + "3");
-        game.addPlayer(playerName + "4");
-        game.dealCards();
+        List<Event> history = Arrays.asList(
+                new GameCreated(ID, GAME_NAME),
+                new PlayerJoined(ID, PLAYER_ONE),
+                new PlayerJoined(ID, PLAYER_TWO),
+                new PlayerJoined(ID, PLAYER_THREE),
+                new PlayerJoined(ID, PLAYER_FOUR),
+                new CardDealt(ID, PLAYER_ONE, A_CARD.suit, A_CARD.value),
+                new CardDealt(ID, PLAYER_ONE, "Spade", "6"),
+                new CardDealt(ID, PLAYER_ONE, "Bastoni", "5"),
+                new CardDealt(ID, PLAYER_TWO, ANOTHER_CARD.suit, ANOTHER_CARD.value),
+                new CardDealt(ID, PLAYER_TWO, "Spade", "1"),
+                new CardDealt(ID, PLAYER_TWO, "Bastoni", "3"),
+                new CardDealt(ID, PLAYER_THREE, "Coppe", "5"),
+                new CardDealt(ID, PLAYER_THREE, "Spade", "6"),
+                new CardDealt(ID, PLAYER_THREE, "Bastoni", "7"),
+                new CardDealt(ID, PLAYER_FOUR, "Denari", "5"),
+                new CardDealt(ID, PLAYER_FOUR, "Bastoni", "6"),
+                new CardDealt(ID, PLAYER_FOUR, "Spade", "7"),
+                new BriscolaSelected(ID,  "Spade", "2")
+        );
 
-        Card aCard = firstCardOfFirstPlayer();
-        Card anotherCard = firstCardOfSecondPlayer();
+        Game game = Game.from(history);
 
-        game.playCard(playerName + "1", aCard);
-        game.playCard(playerName + "2", anotherCard);
+        game.playCard(PLAYER_ONE, A_CARD);
+        game.playCard(PLAYER_TWO, ANOTHER_CARD);
 
         assertThat(game.changes())
                 .filteredOn("class", CardPlayed.class)
                 .extracting("name", "suit", "value")
-                .contains(tuple(playerName + "1", aCard.suit, aCard.value),
-                          tuple(playerName + "2", anotherCard.suit, anotherCard.value)
+                .containsExactly(
+                        tuple(PLAYER_ONE, A_CARD.suit, A_CARD.value),
+                        tuple(PLAYER_TWO, ANOTHER_CARD.suit, ANOTHER_CARD.value)
                 );
     }
 
-    private UUID id = randomUUID();
-    private String gameName = "a game name";
-    private String playerName = "a player name";
-
-    private Card firstCardOfFirstPlayer() {
-        Deck deck = Deck.shuffleWithSeed(id.hashCode());
-        return deck.select(1).get(0);
-    }
-
-    private Card firstCardOfSecondPlayer() {
-        Deck deck = Deck.shuffleWithSeed(id.hashCode());
-        return deck.select(6).get(3);
-    }
+    private static final UUID ID = randomUUID();
+    private static final String GAME_NAME = "a game name";
+    private static final String A_PLAYER_NAME = "a player name";
+    private static final String PLAYER_ONE = A_PLAYER_NAME + "1";
+    private static final String PLAYER_TWO = A_PLAYER_NAME + "2";
+    private static final String PLAYER_THREE = A_PLAYER_NAME + "3";
+    private static final String PLAYER_FOUR = A_PLAYER_NAME + "4";
+    private static final Card A_CARD = new Card("Denari", "2");
+    private static final Card ANOTHER_CARD = new Card("Coppe", "7");
 }

--- a/src/test/java/CardCannotBePlayed.java
+++ b/src/test/java/CardCannotBePlayed.java
@@ -39,7 +39,7 @@ public class CardCannotBePlayed {
 
         assertThatExceptionOfType(InvalidOperationException.class)
                 .isThrownBy(() -> game.playCard(playerName + "1", firstCardOfSecondPlayer))
-                .withMessage("Player can't play a card not in her hand");
+                .withMessage("Player can't play a card not in their hand");
     }
 
     @Test


### PR DESCRIPTION
This PR uses events in order to do the setup of the `CardCanBePlayed_by_players_during_their_turn` test.
This change is also going to make the test independent of the deck shuffling strategy.